### PR TITLE
tests: initialize g_mutex in cond_tests

### DIFF
--- a/verify/thread/cond_test1.c
+++ b/verify/thread/cond_test1.c
@@ -43,6 +43,7 @@ run(void *arg)
 int
 main(void)
 {
+    vmutex_init(&g_mutex);
     launch_threads(NTHREADS, run);
     ASSERT(g_cs_x == NTHREADS);
     ASSERT(g_cs_y == NTHREADS);

--- a/verify/thread/cond_test2.c
+++ b/verify/thread/cond_test2.c
@@ -38,6 +38,7 @@ run(void *arg)
 int
 main(void)
 {
+    vmutex_init(&g_mutex);
     launch_threads(NTHREADS, run);
     ASSERT(g_shared == NTHREADS);
     return 0;

--- a/verify/thread/mock_mutex.h
+++ b/verify/thread/mock_mutex.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2024. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2024-2025. All rights reserved.
  * SPDX-License-Identifier: MIT
  */
 
@@ -10,6 +10,12 @@
     #include <pthread.h>
 
 typedef pthread_mutex_t vmutex_t;
+
+static inline void
+vmutex_init(vmutex_t *l)
+{
+    pthread_mutex_init(l, 0);
+}
 
 static inline void
 vmutex_acquire(vmutex_t *l)
@@ -25,6 +31,11 @@ vmutex_release(vmutex_t *l)
     #include <vsync/caslock.h>
 
 typedef caslock_t vmutex_t;
+
+vmutex_init(vmutex_t *l)
+{
+    caslock_init(l);
+}
 
 static inline void
 vmutex_acquire(vmutex_t *l)


### PR DESCRIPTION
Fixed
- cond_tests uses mock_mutex and the mutex must be initialized