### PR TITLE
Detect skipped checks and fail the CI when that occurs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build Verification Clients for ${{ matrix.test-dir }}
         run: cmake --build build/${{ matrix.test-dir.p }}/${{ matrix.test-dir.c }}
       - name: Run Verification
-        run: ctest --test-dir build/${{ matrix.test-dir.p }}/${{ matrix.test-dir.c }} -V -R check* --output-on-failure
+        run: ctest --test-dir build/${{ matrix.test-dir.p }}/${{ matrix.test-dir.c }} -R check* --output-on-failure
       - name: Upload vsyncer report
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
Change

- once the final checks report is generated, fail the CI
  job/action if an internal error (i.e. skipped check) occurred

---
Signed-off-by: Lilith Oberhauser <lilith.oberhauser@huawei.com>